### PR TITLE
use `require_relative` to load a lib

### DIFF
--- a/make_cv.rb
+++ b/make_cv.rb
@@ -2,7 +2,7 @@
 require "optparse"
 require "prawn"
 require "yaml"
-require "./txt2yaml"
+require_relative "txt2yaml"
 
 $font_faces = Hash.new
 $font_faces["mincho"] = "fonts/ipaexm.ttf"


### PR DESCRIPTION
カレントディレクトリに make_cv.rb が存在しない場合（例えば `ruby ~/yaml_cv/make_cv.rb ....` と実行した場合）に動作しないので、`require_relative`に変更しました。
