### PR TITLE
Manage Prawn with Bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 fonts
 *.pdf
+
+# Bundler
+vendor/bundle/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "prawn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    pdf-core (0.9.0)
+    prawn (2.4.0)
+      pdf-core (~> 0.9.0)
+      ttfunk (~> 1.7)
+    ttfunk (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  prawn
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ YAML形式で書かれたデータファイルと、YAMLもしくはテキスト
 
 PrawnはBundlerで管理しているため、以下のコマンドでインストールしてください。
 
-```shell
+```sh
 $ bundle config path vendor/bundle
 $ bundle install --without=documentation --jobs 4 --retry 3
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ YAML形式で書かれたデータファイルと、YAMLもしくはテキスト
 * Prawn
 * IAPexフォント
 
+PrawnはBundlerで管理しているため、以下のコマンドでインストールしてください。
+
+```shell
+$ bundle config path vendor/bundle
+$ bundle install --without=documentation --jobs 4 --retry 3
+```
+
 Prawnから日本語を出力するためにIPAexフォントを使っています。スクリプトと同じ場所にfontsディレクトリを用意して、[ここ](https://moji.or.jp/ipafont/ipaex00401/)からフォントをダウンロードして以下のように配置してください。
 
 ```txt

--- a/make_cv.rb
+++ b/make_cv.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 require "optparse"
-require "prawn"
+require "bundler"
+Bundler.require
 require "yaml"
 require_relative "txt2yaml"
 


### PR DESCRIPTION
現在、Prawn は手動でグローバルインストールする必要があります。
手動でインストールするのが手間、かつグローバル環境を汚したくないため、Bundler で管理するのが望ましいと考えました。