### PR TITLE
Add font download script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,23 @@ YAML形式で書かれたデータファイルと、YAMLもしくはテキスト
 * Prawn
 * IAPexフォント
 
-Prawnから日本語を出力するためにIPAexフォントを使っています。スクリプトと同じ場所にfontsディレクトリを用意して、[ここ](https://moji.or.jp/ipafont/ipaex00401/)からフォントをダウンロードして以下のように配置してください。
+Prawnから日本語を出力するためにIPAexフォントを使っています。スクリプトと同じ場所にfontsディレクトリを用意しているので、[ここ](https://moji.or.jp/ipafont/ipaex00401/)からフォントをダウンロードして以下のように配置してください。
 
 ```txt
 ├── fonts
 │   ├── ipaexg.ttf
 │   └── ipaexm.ttf
 └── make_cv.rb
+```
+
+コマンドでIPAexフォントをダウンロードしてfontsディレクトリに配置することもできます。
+
+```sh
+$ curl -O https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip
+$ unzip -o IPAexfont00401.zip
+$ mv IPAexfont00401/* fonts/
+$ rm -rf IPAexfont00401g
+$ rm -f IPAexfont00401.zip
 ```
 
 ### 実行方法


### PR DESCRIPTION
フォントをダウンロードして `fonts` フォルダに展開するスクリプトを README に追記しました。