### PR TITLE
Fix error on Ruby 3.1 or higher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "prawn"
+# workaround for Ruby 3.1 and above
+gem "matrix"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    matrix (0.4.2)
     pdf-core (0.9.0)
     prawn (2.4.0)
       pdf-core (~> 0.9.0)
@@ -11,6 +12,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  matrix
   prawn
 
 BUNDLED WITH

--- a/make_cv.rb
+++ b/make_cv.rb
@@ -288,12 +288,12 @@ end
 
 def check_fonts
   $font_faces.each do |k, v|
-    if !File.exists?(v)
+    if !File.exist?(v)
       puts <<EOS
 Font files are not found.
 Please download IPAex fonts via
 
-https://ipafont.ipa.go.jp/node26
+https://moji.or.jp/ipafont/
 
 and place them as 
 


### PR DESCRIPTION
Also this PR updates the download link for IPA fonts.